### PR TITLE
Sb83/feature dungeon (sb84,sb80)

### DIFF
--- a/combat/combat.js
+++ b/combat/combat.js
@@ -31,7 +31,7 @@ const calculatePveHero = (user, npc) => {
 		acc[cur] = randomReward;
 		return acc;
 	}, {});
-	pveResult.expReward = Math.ceil(Math.random() * (npc.stats.attack + npc.stats.health));
+	pveResult.expReward = Math.ceil(Math.random() * (npc.stats.attack + npc.stats.health) / 2);
 }
  else {
 	pveResult.expReward = Math.ceil(Math.random() * 5);
@@ -80,7 +80,7 @@ const calculatePveFullArmyResult = (user, npc) => {
 		acc[cur] = randomReward;
 		return acc;
 	}, {});
-	pveResult.expReward = Math.ceil(Math.random() * (npc.stats.attack + npc.stats.health));
+	pveResult.expReward = Math.ceil(Math.random() * (npc.stats.attack + npc.stats.health) / 2);
 }
  else {
 	pveResult.expReward = Math.ceil(Math.random() * 10);

--- a/combat/pveEmedGenerator.js
+++ b/combat/pveEmedGenerator.js
@@ -1,9 +1,9 @@
 const Discord = require("discord.js");
 const { getResourceIcon, getPlaceIcon } = require("../game/_CONSTS/icons");
 
-function generateEmbedPveFullArmy(user, placeInfo, pveResult) {
+function generateEmbedPveFullArmy(user, placeInfo, pveResult, dungeonRaid = false) {
     if (pveResult.win) {
-        return generateEmbedPveFullArmyWin(user, placeInfo, pveResult);
+        return generateEmbedPveFullArmyWin(user, placeInfo, pveResult, dungeonRaid);
     }
     return generateEmbedPveFullArmyLoss(user, placeInfo, pveResult);
 }
@@ -17,7 +17,7 @@ function generateEmbedPveHero(user, placeInfo, pveResult) {
 
 }
 
-function generateEmbedPveFullArmyWin(user, placeInfo, pveResult) {
+function generateEmbedPveFullArmyWin(user, placeInfo, pveResult, dungeonRaid) {
     const sideColor = "#45b6fe";
     const placeName = placeInfo.name;
     const placeIcon = getPlaceIcon(placeInfo.type);
@@ -40,6 +40,7 @@ function generateEmbedPveFullArmyWin(user, placeInfo, pveResult) {
         expReward += "💪 You leveled up! 💪";
     }
 
+
     const embedWin = new Discord.MessageEmbed()
     .setTitle(title)
     .setColor(sideColor)
@@ -60,6 +61,9 @@ function generateEmbedPveFullArmyWin(user, placeInfo, pveResult) {
             inline: false,
         },
     );
+    if (dungeonRaid) {
+        embedWin.footer = { text:"Proceed to the next room? ✅ / 🚫" };
+    }
 return embedWin;
 }
 

--- a/commands/dungeon.js
+++ b/commands/dungeon.js
@@ -1,9 +1,15 @@
-const { handleDungeon } = require("../game/dungeon");
-
+const { handleDungeonRooms } = require("../game/dungeon/rooms");
+// Possible issues with !dungeon commnd
+/*
+- Other people interfering with the dungeon run
+- Players healing between rounds or otherwise do actions not connected to dungeon
+- If another player triggers the dungeon while someone is in dungeon, the values might copy from current dungeon instead of a new one
+- Possible issue with paralell saving to mongodb when attacking dungeon boss
+*/
 module.exports = {
 	name: "dungeon",
-	description: "Let's the player trigger a dungeon",
+	description: "Let's the player trigger a dungeon with n rooms and a final boss in the end",
 	async execute(message, args, user) {
-		await handleDungeon(message, user);
+		await handleDungeonRooms(message, user);
 		},
 	};

--- a/commands/dungeon.js
+++ b/commands/dungeon.js
@@ -1,10 +1,9 @@
-/* const { handleDungeon } = require("../game/dungeon");
+const { handleDungeon } = require("../game/dungeon");
 
 module.exports = {
 	name: "dungeon",
-	description: "Let's the player attack a dungeon",
-	execute(message, args, user) {
-		// const result = handleDungeon(user);
-		return message.channel.send("This feature has not yet been activated!");
-	},
-}; */
+	description: "Let's the player trigger a dungeon",
+	async execute(message, args, user) {
+		await handleDungeon(message, user);
+		},
+	};

--- a/commands/travel.js
+++ b/commands/travel.js
@@ -1,0 +1,14 @@
+const { handleTravel } = require("../game/travel");
+
+module.exports = {
+	name: "travel",
+	description: "Let's player travel to other locations that has been previously explored",
+	async execute(message, args, user) {
+        if (!args.length) {
+            return message.channel.send("Where do you want to travel to?");
+		}
+		const location = args.join("").toLowerCase();
+		const result = await handleTravel(user, location);
+		return message.channel.send(result);
+	},
+};

--- a/game/_CONSTS/cooldowns.js
+++ b/game/_CONSTS/cooldowns.js
@@ -5,7 +5,7 @@ const Discord = require("discord.js");
 const cooldowns = {
 	dailyPrize:(1000 * 60 * 60 * 24),
 	duel: (1000 * 60 * 2),
-	dungeon:(1000 * 60 * 60 * 12),
+	dungeon:(1000/*  * 60 * 60 * 12 */),
 	explore: (1000 * 30),
 	fish:(1000 * 15),
 	hunt:(1000 * 20),

--- a/game/_CONSTS/explore.js
+++ b/game/_CONSTS/explore.js
@@ -118,43 +118,48 @@ const worldLocations = {
 				type: "dungeon",
 				rooms:[
 					{
-						name: "Castle guards",
+						name: "Castle Courtyard",
 						attack: 100,
 						health: 100,
 					},
 					{
-						name: "Castle servents",
+						name: "Castle Hallway",
 						attack: 200,
 						health: 200,
 					},
 					{
-						name: "Castle protector",
+						name: "Castle Trophey Room",
 						attack: 300,
 						health: 300,
 					},
 				],
-				rules:{
-					allowArmy: false,
-					canKill: true,
-					allowHelpers: true,
-				},
-				rewards:{
-					gold:5000,
-					xp:1100,
-					drop: true,
-				},
-				allowedWeapons:["slash", "strike", "critical", "disarm", "heal"],
-				bossWeapons:["slash", "strike", "heal"],
-				/* "285773285944328193" */
-				helpers:[],
 				requires: "Ogre tooth",
-				unlocks: "Misty Mountains",
-				stats:{
-					attack: 500,
-					health:500,
-					currentHealth:500,
-					healing:true,
+				boss:{
+					name: "Bandit King",
+					rules:{
+						attacksEachRound:2,
+						allowArmy: false,
+						canKill: true,
+						allowHelpers: true,
+					},
+					rewards:{
+						gold:5000,
+						xp:1100,
+						drop: true,
+					},
+					stats:{
+						attack: 500,
+						health:500,
+						currentHealth:500,
+						healing:true,
+					},
+					bossWeapons:["slash", "strike", "heal"],
+					helpers:["285773285944328193"],
+					numOfAllowedWeapons: 3,
+					allowedWeapons:[],
+					unlocks: "Misty Mountains",
 				},
+
 			},
 			River: {
 				name: "River",

--- a/game/_CONSTS/explore.js
+++ b/game/_CONSTS/explore.js
@@ -116,6 +116,23 @@ const worldLocations = {
 			"Bandit's Castle": {
 				name: "Bandit's Castle",
 				type: "dungeon",
+				rooms:[
+					{
+						name: "Castle guards",
+						attack: 100,
+						health: 100,
+					},
+					{
+						name: "Castle servents",
+						attack: 200,
+						health: 200,
+					},
+					{
+						name: "Castle protector",
+						attack: 300,
+						health: 300,
+					},
+				],
 				rules:{
 					allowArmy: false,
 					canKill: true,
@@ -124,6 +141,7 @@ const worldLocations = {
 				rewards:{
 					gold:5000,
 					xp:1100,
+					drop: true,
 				},
 				helpers:[],
 				requires: "Ogre tooth",
@@ -131,6 +149,7 @@ const worldLocations = {
 				stats:{
 					attack: 500,
 					health:500,
+					currentHealth:500,
 					healing:false,
 				},
 			},

--- a/game/_CONSTS/explore.js
+++ b/game/_CONSTS/explore.js
@@ -143,6 +143,9 @@ const worldLocations = {
 					xp:1100,
 					drop: true,
 				},
+				allowedWeapons:["slash", "strike", "critical", "disarm", "heal"],
+				bossWeapons:["slash", "strike", "heal"],
+				/* "285773285944328193" */
 				helpers:[],
 				requires: "Ogre tooth",
 				unlocks: "Misty Mountains",
@@ -150,7 +153,7 @@ const worldLocations = {
 					attack: 500,
 					health:500,
 					currentHealth:500,
-					healing:false,
+					healing:true,
 				},
 			},
 			River: {

--- a/game/_CONSTS/explore.js
+++ b/game/_CONSTS/explore.js
@@ -142,6 +142,12 @@ const worldLocations = {
 						canKill: true,
 						allowHelpers: true,
 					},
+					roundDescriptions:[
+						"You enter the very last room of the castle, seing the very foe you came to seek. Your personal army shivers in fear in the face of the Castle's Monarch, they can't help you fight this boss. Choose your weapon wisely to defeat the **Bandit King**!",
+						"Choose your weapon wisely!",
+						"Choose your weapon wisely!",
+						"Choose your weapon wisely!",
+					],
 					rewards:{
 						gold:5000,
 						xp:1100,
@@ -149,11 +155,12 @@ const worldLocations = {
 					},
 					stats:{
 						attack: 500,
-						health:500,
-						currentHealth:500,
+						health:20000,
+						currentHealth:20000,
 						healing:true,
 					},
-					bossWeapons:["slash", "strike", "heal"],
+					/* , "heal" */
+					bossWeapons:["slash", "strike"],
 					helpers:["285773285944328193"],
 					numOfAllowedWeapons: 3,
 					allowedWeapons:[],

--- a/game/_CONSTS/explore.js
+++ b/game/_CONSTS/explore.js
@@ -116,11 +116,22 @@ const worldLocations = {
 			"Bandit's Castle": {
 				name: "Bandit's Castle",
 				type: "dungeon",
+				rules:{
+					allowArmy: false,
+					canKill: true,
+					allowHelpers: true,
+				},
+				rewards:{
+					gold:5000,
+					xp:1100,
+				},
+				helpers:[],
 				requires: "Ogre tooth",
 				unlocks: "Misty Mountains",
 				stats:{
 					attack: 500,
 					health:500,
+					healing:false,
 				},
 			},
 			River: {
@@ -247,6 +258,16 @@ const worldLocations = {
 			"Windlow Volcano": {
 				name: "Windlow Volcano",
 				type: "dungeon",
+				rules:{
+					allowArmy: false,
+					canKill: true,
+					allowHelpers: true,
+				},
+				rewards:{
+					gold:5000,
+					xp:1100,
+				},
+				helpers:[],
 				requires: "Eridian Vase",
 				stats:{
 					attack: 500,
@@ -379,6 +400,16 @@ const worldLocations = {
 				name: "Collapsing Sanctuary",
 				requires: "The One Shell",
 				type: "dungeon",
+				rules:{
+					allowArmy: false,
+					canKill: true,
+					allowHelpers: true,
+				},
+				rewards:{
+					gold:5000,
+					xp:1100,
+				},
+				helpers:[],
 				stats:{
 					attack: 500,
 					health:500,

--- a/game/_CONSTS/explore.js
+++ b/game/_CONSTS/explore.js
@@ -1,6 +1,6 @@
 const worldLocations = {
 	"Grassy Plains": {
-		description: "1st world. Here you can find all the noobs, such as yourself",
+		description: "Here you can find all the noobs, such as yourself",
 		randomEvents: {
 			"Highlanders": {
 				name: "Highlanders",
@@ -113,27 +113,51 @@ const worldLocations = {
 				},
 				helpers:[],
 			},
-			"Bandit's Castle": {
-				name: "Bandit's Castle",
+			"Windlow Volcano": {
+				name: "Windlow Volcano",
 				type: "dungeon",
+				requires: "Ogre tooth",
 				rooms:[
 					{
 						name: "Castle Courtyard",
-						attack: 100,
-						health: 100,
+						type: "raid",
+						stats:{
+							attack: 200,
+							health:200,
+						},
+						rewards:{
+							gold: 50,
+							"copper ore": 100,
+							"iron ore": 60,
+						},
 					},
 					{
 						name: "Castle Hallway",
-						attack: 200,
-						health: 200,
+						type: "raid",
+						stats:{
+							attack: 200,
+							health:200,
+						},
+						rewards:{
+							gold: 50,
+							"copper ore": 100,
+							"iron ore": 60,
+						},
 					},
 					{
 						name: "Castle Trophey Room",
-						attack: 300,
-						health: 300,
+						type: "raid",
+						stats:{
+							attack: 200,
+							health:200,
+						},
+						rewards:{
+							gold: 50,
+							"copper ore": 100,
+							"iron ore": 60,
+						},
 					},
 				],
-				requires: "Ogre tooth",
 				boss:{
 					name: "Bandit King",
 					rules:{
@@ -151,17 +175,16 @@ const worldLocations = {
 					rewards:{
 						gold:5000,
 						xp:1100,
-						drop: true,
+						drop: ["greatsword of the spring", "bauxite daggers", "Large Heal Potion", "Small Heal Potion"],
 					},
 					stats:{
 						attack: 500,
-						health:20000,
-						currentHealth:20000,
+						health:2000,
+						currentHealth:2000,
 						healing:true,
 					},
-					/* , "heal" */
-					bossWeapons:["slash", "strike"],
-					helpers:["285773285944328193"],
+					bossWeapons:["slash", "strike", "heal"],
+					helpers:[],
 					numOfAllowedWeapons: 3,
 					allowedWeapons:[],
 					unlocks: "Misty Mountains",
@@ -176,7 +199,7 @@ const worldLocations = {
 		},
 	},
 	"Misty Mountains":{
-		description: "2nd world. You've entered a hostile environment where rewards are equally big as the threats",
+		description: "You've entered a hostile environment where rewards are equally big as the threats",
 		randomEvents: {
 			"Mountain Bandits": {
 				name: "Mountain Bandits",
@@ -292,32 +315,95 @@ const worldLocations = {
 			"Windlow Volcano": {
 				name: "Windlow Volcano",
 				type: "dungeon",
-				rules:{
-					allowArmy: false,
-					canKill: true,
-					allowHelpers: true,
-				},
-				rewards:{
-					gold:5000,
-					xp:1100,
-				},
-				helpers:[],
 				requires: "Eridian Vase",
-				stats:{
-					attack: 500,
-					health:500,
+				rooms:[
+					{
+						name: "Volcano Foot",
+						type: "raid",
+						stats:{
+							attack: 200,
+							health:200,
+						},
+						rewards:{
+							gold: 50,
+							"copper ore": 100,
+							"iron ore": 60,
+						},
+					},
+					{
+						name: "Volcano Vent",
+						type: "raid",
+						stats:{
+							attack: 200,
+							health:200,
+						},
+						rewards:{
+							gold: 50,
+							"copper ore": 100,
+							"iron ore": 60,
+						},
+					},
+					{
+						name: "Magma Chamber",
+						type: "raid",
+						stats:{
+							attack: 200,
+							health:200,
+						},
+						rewards:{
+							gold: 50,
+							"copper ore": 100,
+							"iron ore": 60,
+						},
+					},
+				],
+				boss:{
+					name: "Volcano King",
+					rules:{
+						attacksEachRound:2,
+						allowArmy: false,
+						canKill: true,
+						allowHelpers: true,
+					},
+					roundDescriptions:[
+						"You enter the very last room of the castle, seing the very foe you came to seek. Your personal army shivers in fear in the face of the Castle's Monarch, they can't help you fight this boss. Choose your weapon wisely to defeat the **Volcano King**!",
+						"Choose your weapon wisely!",
+						"Choose your weapon wisely!",
+						"Choose your weapon wisely!",
+					],
+					rewards:{
+						gold:5000,
+						xp:1100,
+						drop: ["greatsword of the spring", "bauxite daggers", "Large Heal Potion", "Small Heal Potion"],
+					},
+					stats:{
+						attack: 500,
+						health:2000,
+						currentHealth:2000,
+						healing:true,
+					},
+					bossWeapons:["slash", "strike", "heal"],
+					helpers:[],
+					numOfAllowedWeapons: 3,
+					allowedWeapons:[],
+					unlocks: "Deep Caves",
 				},
-				unlocks:"Deep Caves",
+
 			},
+			River: {
+				name: "River",
+				type: "fish",
+				fish: ["Cod", "Trout", "Swordfish"],
+			},
+		},
 		["Cold Boiling Lake"]: {
 				name: "Cold Boiling Lake",
 				type: "fish",
 				fish: ["Cod", "Trout", "Swordfish", "Salmon", "Macrel"],
 			},
-		},
 	},
 	"Deep Caves":{
-		description: "3rd world. You're in one of the darkest and most forgotten places of Mega RPG",
+		description: "You're in one of the darkest and most forgotten places of Mega RPG",
 		randomEvents: {
 			"Lost skeletons": {
 				name: "Lost skeletons",

--- a/game/_CONSTS/icons.js
+++ b/game/_CONSTS/icons.js
@@ -28,6 +28,18 @@ const getDungeonKeyIcon = (type) =>{
 	return lexicon[type];
 };
 
+const getWeaponIcon = (weapon)=>{
+	const lexicon = {
+		strike: "🔪",
+		critical: "‼️",
+		slash: "🗡",
+		disarm: "🕊",
+		heal: "🧪",
+
+	};
+	return lexicon[weapon];
+};
+
 const getGreenRedIcon = (bool)=>{
 	return bool ? "✅" : "❌";
 };
@@ -56,4 +68,4 @@ const getStatsIcon = (type)=>{
 	return lexicon[type];
 };
 
-module.exports = { getLocationIcon, getPlaceIcon, getResourceIcon, getDungeonKeyIcon, getGreenRedIcon, getStatsIcon };
+module.exports = { getLocationIcon, getPlaceIcon, getResourceIcon, getDungeonKeyIcon, getGreenRedIcon, getStatsIcon, getWeaponIcon };

--- a/game/_CONSTS/icons.js
+++ b/game/_CONSTS/icons.js
@@ -35,6 +35,7 @@ const getWeaponIcon = (weapon)=>{
 		slash: "🗡",
 		disarm: "🕊",
 		heal: "🧪",
+		poke: "👉",
 
 	};
 	return lexicon[weapon];

--- a/game/_CONSTS/icons.js
+++ b/game/_CONSTS/icons.js
@@ -43,4 +43,13 @@ const getResourceIcon = (type)=>{
 	return lexicon[type];
 };
 
-module.exports = { getLocationIcon, getPlaceIcon, getResourceIcon, getDungeonIcon, getGreenRedIcon };
+const getStatsIcon = (type)=>{
+	const lexicon = {
+	["health"]: ":heart:",
+	["attack"]: ":crossed_swords:",
+	["defense"]: ":shield:",
+	};
+	return lexicon[type];
+};
+
+module.exports = { getLocationIcon, getPlaceIcon, getResourceIcon, getDungeonIcon, getGreenRedIcon, getStatsIcon };

--- a/game/_CONSTS/icons.js
+++ b/game/_CONSTS/icons.js
@@ -36,7 +36,6 @@ const getWeaponIcon = (weapon)=>{
 		disarm: "🕊",
 		heal: "🧪",
 		poke: "👉",
-
 	};
 	return lexicon[weapon];
 };

--- a/game/_CONSTS/icons.js
+++ b/game/_CONSTS/icons.js
@@ -1,4 +1,5 @@
 const getLocationIcon = (worldLocation)=>{
+
 	const lexicon = {
 		"Grassy Plains" : "🌳",
 		"Misty Mountains" : "🏔",
@@ -17,7 +18,7 @@ const getPlaceIcon = (type) => {
 	};
 	return lexicon[type];
 };
-const getDungeonIcon = (type) =>{
+const getDungeonKeyIcon = (type) =>{
 	const lexicon = {
 		["Ogre tooth"]:"🦷",
 		["The One Shell"]:"🐚",
@@ -55,4 +56,4 @@ const getStatsIcon = (type)=>{
 	return lexicon[type];
 };
 
-module.exports = { getLocationIcon, getPlaceIcon, getResourceIcon, getDungeonIcon, getGreenRedIcon, getStatsIcon };
+module.exports = { getLocationIcon, getPlaceIcon, getResourceIcon, getDungeonKeyIcon, getGreenRedIcon, getStatsIcon };

--- a/game/dungeon/embedGenerator.js
+++ b/game/dungeon/embedGenerator.js
@@ -7,20 +7,20 @@ const createDungeonInvitation = (dungeon, user)=>{
     const { currentLocation } = user.world;
     const locationIcon = getLocationIcon(currentLocation);
     const dungeonIcon = getPlaceIcon("dungeon");
-        const rules = `${getGreenRedIcon(dungeon.rules.allowArmy)} \`Army allowed\`\n ${getGreenRedIcon(dungeon.rules.canKill)} \`Dungeon deadly\`\n${getGreenRedIcon(dungeon.rules.allowHelpers)} \`Helpers allowed\`\n\n**Unclocks**: ${getLocationIcon(dungeon.unlocks)} **${dungeon.unlocks}**\n`;
-        const dungeonStats = `${getStatsIcon("health")} \`Health: ${dungeon.stats.health}\`\n ${getStatsIcon("attack")} \`Attack: ${dungeon.stats.attack}\`\n ${getGreenRedIcon(dungeon.stats.healing)} \`Healing\`\n`;
-        const bossRewards = `${getResourceIcon("gold")} \`Gold: ${dungeon.rewards.gold}\`\n ${getResourceIcon("xp")} \`XP: ${dungeon.rewards.xp}\`\n${getGreenRedIcon(dungeon.rewards.drop)} \`Loot drop\`\n\n   `;
-        const bossWeapons = dungeon.bossWeapons.map(w=>{
+        const rules = `${getGreenRedIcon(dungeon.boss.rules.allowArmy)} \`Army allowed\`\n ${getGreenRedIcon(dungeon.boss.rules.canKill)} \`Dungeon deadly\`\n${getGreenRedIcon(dungeon.boss.rules.allowHelpers)} \`Helpers allowed\`\n\n**Unclocks**: ${getLocationIcon(dungeon.boss.unlocks)} **${dungeon.boss.unlocks}**\n`;
+        const dungeonStats = `${getStatsIcon("health")} \`Health: ${dungeon.boss.stats.health}\`\n ${getStatsIcon("attack")} \`Attack: ${dungeon.boss.stats.attack}\`\n ${getGreenRedIcon(dungeon.boss.stats.healing)} \`Healing\`\n`;
+        const bossRewards = `${getResourceIcon("gold")} \`Gold: ${dungeon.boss.rewards.gold}\`\n ${getResourceIcon("xp")} \`XP: ${dungeon.boss.rewards.xp}\`\n${getGreenRedIcon(dungeon.boss.rewards.drop)} \`Loot drop\`\n\n   `;
+        const bossWeapons = dungeon.boss.bossWeapons.map(w=>{
             return `${getWeaponIcon(w)} \`${w}\``;
         });
 
         const fields = [{
-            name: `${dungeon.name}'s Boss stats:`,
+            name: `${dungeon.boss.name}'s Boss stats:`,
             value: dungeonStats,
             inline:true,
         },
         {
-            name: `${dungeon.name}'s Boss weapons:`,
+            name: `${dungeon.boss.name}'s weapons:`,
             value: bossWeapons,
             inline: true,
         },
@@ -37,14 +37,14 @@ const createDungeonInvitation = (dungeon, user)=>{
         },
 
         {
-            name: `${dungeon.name}'s Boss reward:`,
+            name: `${dungeon.boss.name}'s rewards:`,
             value: bossRewards,
             inline: true,
         }];
 
         const embedInvitation = new Discord.MessageEmbed()
             .setTitle(`${username} is going for the dungeon boss!!`)
-            .setDescription(`Help taking out ${dungeonIcon} ${dungeon.name} Boss in ${locationIcon} ${currentLocation}!`)
+            .setDescription(`Help taking out ${dungeonIcon} **${dungeon.boss.name}** in ${locationIcon} ${currentLocation}!`)
             .setColor(sideColor)
             .addFields(
                 ...fields,
@@ -55,39 +55,41 @@ const createDungeonInvitation = (dungeon, user)=>{
 
     const generateDungeonBossRound = (progress)=>{
 
-        const weapons = {
+        const weapons = progress.dungeon.boss.allowedWeapons;
+        /* const weapons = {
             a: { name:"slash", desc: "95% chance of causing up to 1 times the max attack" },
             b: { name: "strike", desc: "80% chance of causing up to 2 times the max attack" },
             c: { name: "critical", desc: "40% chance of causing up to 4 times the max attack" },
             d: { name:"disarm", desc: "25% chance of lowering boss attack" },
             e: { name: "heal", desc: "95% chance of healing teammate with lowest hp" },
-        };
-
+        }; */
 
         const sideColor = "#45b6fe";
         const initiativeTakerName = progress.initiativeTaker.account.username;
-        const gangNames = progress.players.map(p=>{
-            return p.account.username;
-        });
+        const gangNames = progress.players
+            .filter(p=> p.account.username !== initiativeTakerName)
+            .map(p=>p.account.username);
         const dungeonName = progress.dungeon.name;
         const dungeonIcon = getPlaceIcon("dungeon");
 
-        const dungeonHp = getDungeonHp(progress.dungeon.stats);
-        const playersHp = getPlayersHp(progress.players, progress.dungeon.helpers);
+        const bossName = progress.dungeon.boss.name;
+
+        const dungeonHp = getDungeonHp(progress.dungeon.boss.stats);
+        const playersHp = getPlayersHp(progress.players, progress.dungeon.boss.helpers);
 
         const title = `${dungeonIcon} ${dungeonName} ~~~ BOSS FIGHT`;
 
         const weaponsTitle = "Choose your weapon:";
         const weaponsOverview = Object.keys(weapons).map(w=>{
-            const { name, desc } = weapons[w];
-            return `${getWeaponIcon(name)} ${w}) **${name}** ${desc}\n`;
+            const { answer, name, description } = weapons[w];
+            return `${getWeaponIcon(name)} ${answer}) **${name}** ${description}\n`;
         });
 
         const footer = "TIP: Write your weapon of choice in the chat. eg -> a or c";
 
         const fields = [
             {
-                name: `${dungeonName} Boss HP:`,
+                name: `${bossName} HP:`,
                 value: dungeonHp,
                 inline: true,
             },
@@ -112,7 +114,6 @@ const createDungeonInvitation = (dungeon, user)=>{
                 inline: true,
             },
         ];
-        console.log(fields, "fields");
 
         const embedResult = new Discord.MessageEmbed()
             .setTitle(title)

--- a/game/dungeon/embedGenerator.js
+++ b/game/dungeon/embedGenerator.js
@@ -1,0 +1,119 @@
+const Discord = require("discord.js");
+const { getLocationIcon, getStatsIcon, getPlaceIcon, getDungeonIcon, getGreenRedIcon, getResourceIcon } = require("../_CONSTS/icons");
+
+const createDungeonInvitation = (dungeon, user)=>{
+    const sideColor = "#45b6fe";
+    const username = user.account.username;
+    const { currentLocation } = user.world;
+    const locationIcon = getLocationIcon(currentLocation);
+    const dungeonIcon = getPlaceIcon("dungeon");
+
+        const rules = `\`Army allowed: ${getGreenRedIcon(dungeon.rules.allowArmy)}\`\n \`Dungeon deadly: ${getGreenRedIcon(dungeon.rules.canKill)}\`\n \`Helpers allowed: ${getGreenRedIcon(dungeon.rules.allowHelpers)}\``;
+        const dungeonStats = `${getStatsIcon("health")} \`Health: ${dungeon.stats.health}\`\n ${getStatsIcon("attack")} \`Attack: ${dungeon.stats.attack}\`\n Healing: ${getGreenRedIcon(dungeon.stats.healing)}`;
+        const rewards = `${getResourceIcon("gold")} \`Gold: ${dungeon.rewards.gold}\`\n ${getResourceIcon("xp")} \`XP: ${dungeon.rewards.xp}\` \n ${getDungeonIcon(dungeon.rewards.dungeonKey)} \` Unclocks: ${getLocationIcon(dungeon.unlocks)} ${dungeon.unlocks}\``;
+
+        const embedInvitation = new Discord.MessageEmbed()
+            .setTitle(`${username} is attempting a dungeon!!`)
+            .setDescription(`Help taking out ${dungeonIcon} ${dungeon.name} in ${locationIcon} ${currentLocation} `)
+            .setColor(sideColor)
+            .addFields(
+                {
+                    name: `${dungeon.name}'s stats:`,
+                    value: dungeonStats,
+                    inline:true,
+                },
+                {
+                    name: "Rules",
+                    value: rules,
+                    inline: true,
+                },
+                {
+                    name: `${dungeon.name}'s reward:`,
+                    value: rewards,
+                    inline: false,
+                },
+            )
+            .setFooter(`React with a ${getPlaceIcon("dungeon")} within 20 seconds to participate! (max 5!)`);
+        return embedInvitation;
+    };
+
+    const createDungeonResult = (result, dungeon)=>{
+        if (result.win) {
+            return createMiniBossResultWin(result, dungeon);
+        }
+        return createMiniBossResultLoss(result, dungeon);
+    };
+
+    const createMiniBossResultLoss = (result, dungeon) =>{
+        const sideColor = "#45b6fe";
+        const initiativeTaker = result.initiativeTaker.account.username;
+
+        const initiativeTakerDamage = `-${result.damageDealt.initiativeTaker} HP`;
+
+        const dungeonIcon = getPlaceIcon("dungeon");
+        const fields = [
+            {
+                name: `${initiativeTaker}`,
+                value: initiativeTakerDamage,
+                inline: false,
+            },
+        ];
+        if (result.helpers.length) {
+            const helpersValue = result.helpers.map((h, i)=>`${h.account.username}:\n - ${result.rewards.helpers[i].randomHelperDamage}hp ${result.rewards.helpers[i].helperDead ? "💀" : ""}\n\n`);
+            fields.push({
+                name: "Helpers damage",
+                value: helpersValue,
+                inline: false,
+            });
+        }
+
+        const embedResult = new Discord.MessageEmbed()
+            .setTitle(`${initiativeTaker} ${result.helpers.length ? "and his helpers" : ""} failed to defeat ${dungeonIcon} ${dungeon.name} `)
+            .setDescription("Damage taken: ")
+            .setColor(sideColor)
+            .addFields(
+                ...fields,
+            );
+
+        return embedResult;
+
+    };
+
+
+    const createMiniBossResultWin = (result, dungeon) =>{
+
+        const sideColor = "#45b6fe";
+        const initiativeTaker = result.initiativeTaker.account.username;
+
+        let initiativeTakerRewards = `${getResourceIcon("gold")} Gold: ${result.rewards.initiativeTaker.gold} \n\n ${getResourceIcon("xp")} XP: ${result.rewards.initiativeTaker.xp}`;
+        if (result.rewards.initiativeTaker.dungeonKey) {
+            initiativeTakerRewards += `\n\n ${getDungeonIcon(result.rewards.initiativeTaker.dungeonKey)} ${result.rewards.initiativeTaker.dungeonKey} !`;
+        }
+        const dungeonIcon = getPlaceIcon("dungeon");
+        const fields = [
+            {
+                name: `${initiativeTaker} rewards`,
+                value: initiativeTakerRewards,
+                inline: true,
+            },
+        ];
+        if (result.helpers.length) {
+            fields.push({
+                name: "Helpers rewards",
+                value: result.helpers.map((h, i)=> `${result.rewards.helpers[i].helperName}:\n${getResourceIcon("gold")} Gold: ${result.rewards.helpers[i].randomHelperGold} \n ${getResourceIcon("xp")} XP: ${result.rewards.helpers[i].randomHelperXp}${result.rewards.helpers[i].helperLeveledUp ? " 💪" : ""}\n\n`),
+                inline: true,
+            });
+        }
+
+        const embedResult = new Discord.MessageEmbed()
+            .setTitle(`${initiativeTaker} ${result.helpers.length ? "and his helpers" : ""} successfuly defeated ${dungeonIcon} ${dungeon.name} `)
+            .setDescription("Rewards will be distributed: ")
+            .setColor(sideColor)
+            .addFields(
+                ...fields,
+            );
+        return embedResult;
+        };
+
+
+            module.exports = { createDungeonInvitation, createDungeonResult };

--- a/game/dungeon/embedGenerator.js
+++ b/game/dungeon/embedGenerator.js
@@ -1,5 +1,5 @@
 const Discord = require("discord.js");
-const { getLocationIcon, getStatsIcon, getPlaceIcon, getDungeonIcon, getGreenRedIcon, getResourceIcon } = require("../_CONSTS/icons");
+const { getLocationIcon, getStatsIcon, getPlaceIcon, getDungeonKeyIcon, getGreenRedIcon, getResourceIcon } = require("../_CONSTS/icons");
 
 const createDungeonInvitation = (dungeon, user)=>{
     const sideColor = "#45b6fe";
@@ -7,14 +7,13 @@ const createDungeonInvitation = (dungeon, user)=>{
     const { currentLocation } = user.world;
     const locationIcon = getLocationIcon(currentLocation);
     const dungeonIcon = getPlaceIcon("dungeon");
-
-        const rules = `\`Army allowed: ${getGreenRedIcon(dungeon.rules.allowArmy)}\`\n \`Dungeon deadly: ${getGreenRedIcon(dungeon.rules.canKill)}\`\n \`Helpers allowed: ${getGreenRedIcon(dungeon.rules.allowHelpers)}\``;
-        const dungeonStats = `${getStatsIcon("health")} \`Health: ${dungeon.stats.health}\`\n ${getStatsIcon("attack")} \`Attack: ${dungeon.stats.attack}\`\n Healing: ${getGreenRedIcon(dungeon.stats.healing)}`;
-        const rewards = `${getResourceIcon("gold")} \`Gold: ${dungeon.rewards.gold}\`\n ${getResourceIcon("xp")} \`XP: ${dungeon.rewards.xp}\` \n ${getDungeonIcon(dungeon.rewards.dungeonKey)} \` Unclocks: ${getLocationIcon(dungeon.unlocks)} ${dungeon.unlocks}\``;
+        const rules = `\`Army allowed: ${getGreenRedIcon(dungeon.rules.allowArmy)}\`\n \`Dungeon deadly: ${getGreenRedIcon(dungeon.rules.canKill)}\`\n \`Helpers allowed: ${getGreenRedIcon(dungeon.rules.allowHelpers)}\`\n`;
+        const dungeonStats = `${getStatsIcon("health")} \`Health: ${dungeon.stats.health}\`\n ${getStatsIcon("attack")} \`Attack: ${dungeon.stats.attack}\`\n \`Healing: ${getGreenRedIcon(dungeon.stats.healing)}\`\n`;
+        const rewards = `${getResourceIcon("gold")} \`Gold: ${dungeon.rewards.gold}\`\n ${getResourceIcon("xp")} \`XP: ${dungeon.rewards.xp}\`\n\`Loot drop: ${getGreenRedIcon(dungeon.rewards.drop)}\`\n\n   **Unclocks**: ${getLocationIcon(dungeon.unlocks)} **${dungeon.unlocks}**\n`;
 
         const embedInvitation = new Discord.MessageEmbed()
             .setTitle(`${username} is attempting a dungeon!!`)
-            .setDescription(`Help taking out ${dungeonIcon} ${dungeon.name} in ${locationIcon} ${currentLocation} `)
+            .setDescription(`Help taking out ${dungeonIcon} ${dungeon.name} in ${locationIcon} ${currentLocation}!`)
             .setColor(sideColor)
             .addFields(
                 {
@@ -37,6 +36,62 @@ const createDungeonInvitation = (dungeon, user)=>{
         return embedInvitation;
     };
 
+    const generateDungeonRound = (progress)=>{
+
+
+        const sideColor = "#45b6fe";
+        const initiativeTakerName = progress.initiativeTaker.account.username;
+        const dungeonName = progress.dungeon.name;
+        const dungeonIcon = getPlaceIcon("dungeon");
+
+        const getPlayersHp = (players)=>{
+            // embed get's messed up if hp bar is longer than 20
+            const MAX_REPEATING = 20;
+            const totalPlayerHealth = players.reduce((acc, curr)=> acc + curr.hero.health, 0);
+            const totalPlayerCurrentHealth = players.reduce((acc, curr)=> acc + curr.hero.currentHealth, 0);
+            const percentageHealth = (totalPlayerCurrentHealth / totalPlayerHealth * 100) * MAX_REPEATING / 100;
+            const percentageMissingHealth = MAX_REPEATING - percentageHealth;
+
+            return `\`\`\`diff\n+ ${"|".repeat(percentageHealth)}${" ".repeat(percentageMissingHealth)} \n \`\`\``;
+        };
+        const getDungeonHp = (stats)=>{
+            const MAX_REPEATING = 20;
+            const percentageHealth = (stats.currentHealth / stats.health * 100) * MAX_REPEATING / 100;
+            const percentageMissingHealth = MAX_REPEATING - percentageHealth;
+
+            return `\`\`\`diff\n- ${"|".repeat(percentageHealth)}${" ".repeat(percentageMissingHealth)} \n \`\`\``;
+        };
+
+
+        const dungeonHp = getDungeonHp(progress.dungeon.stats);
+        const playersHp = getPlayersHp(progress.players);
+
+        const title = `${dungeonIcon} ${dungeonName}`;
+
+        const fields = [
+            {
+                name: `${dungeonName} HP:`,
+                value: dungeonHp,
+                inline: true,
+            },
+            {
+                name: `${initiativeTakerName}'s gang total HP:`,
+                value: playersHp,
+                inline: true,
+            },
+        ];
+
+        const embedResult = new Discord.MessageEmbed()
+            .setTitle(title)
+            .setDescription("Round description ")
+            .setColor(sideColor)
+            .addFields(
+                ...fields,
+            );
+        return embedResult;
+    };
+
+
     const createDungeonResult = (result, dungeon)=>{
         if (result.win) {
             return createMiniBossResultWin(result, dungeon);
@@ -44,7 +99,9 @@ const createDungeonInvitation = (dungeon, user)=>{
         return createMiniBossResultLoss(result, dungeon);
     };
 
-    const createMiniBossResultLoss = (result, dungeon) =>{
+    const createMiniBossResultLoss = (message, dungeon) =>{
+
+
         const sideColor = "#45b6fe";
         const initiativeTaker = result.initiativeTaker.account.username;
 
@@ -87,7 +144,7 @@ const createDungeonInvitation = (dungeon, user)=>{
 
         let initiativeTakerRewards = `${getResourceIcon("gold")} Gold: ${result.rewards.initiativeTaker.gold} \n\n ${getResourceIcon("xp")} XP: ${result.rewards.initiativeTaker.xp}`;
         if (result.rewards.initiativeTaker.dungeonKey) {
-            initiativeTakerRewards += `\n\n ${getDungeonIcon(result.rewards.initiativeTaker.dungeonKey)} ${result.rewards.initiativeTaker.dungeonKey} !`;
+            initiativeTakerRewards += `\n\n ${getDungeonKeyIcon(result.rewards.initiativeTaker.dungeonKey)} ${result.rewards.initiativeTaker.dungeonKey} !`;
         }
         const dungeonIcon = getPlaceIcon("dungeon");
         const fields = [
@@ -116,4 +173,4 @@ const createDungeonInvitation = (dungeon, user)=>{
         };
 
 
-            module.exports = { createDungeonInvitation, createDungeonResult };
+            module.exports = { createDungeonInvitation, createDungeonResult, generateDungeonRound };

--- a/game/dungeon/helper.js
+++ b/game/dungeon/helper.js
@@ -74,7 +74,7 @@ const getWeaponInfo = (weapon, num = null)=>{
     }
     return weaponInformation;
 };
-const dungeonBossStartAllowed = (user)=>{
+const dungeonStartAllowed = (user)=>{
     // checks for cooldown
     const cooldownInfo = onCooldown("dungeon", user);
     if (cooldownInfo.response) {
@@ -119,4 +119,4 @@ const randomIntBetweenMinMax = (min, max) => {
     return Math.floor(Math.random() * (max - min + 1) + min);
   };
 
-module.exports = { getWeaponInfo, dungeonBossStartAllowed, validateHelper, randomIntBetweenMinMax };
+module.exports = { getWeaponInfo, dungeonStartAllowed, validateHelper, randomIntBetweenMinMax };

--- a/game/dungeon/helper.js
+++ b/game/dungeon/helper.js
@@ -1,0 +1,122 @@
+const User = require("../../models/User");
+const { getLocationIcon, getDungeonKeyIcon } = require("../_CONSTS/icons");
+const { worldLocations } = require("../_CONSTS/explore");
+const { onCooldown } = require("../_CONSTS/cooldowns");
+const getWeaponInfo = (weapon, num = null)=>{
+    const weaponInformation = {
+        "slash":{
+            name: "slash",
+            type: "attack",
+            answer: null,
+            chanceforSuccess: 0.95,
+            damage: 1,
+            description: "\n95% chance of slashing the enemy",
+        },
+        "strike":{
+            name: "strike",
+            type: "attack",
+            answer: null,
+            chanceforSuccess: 0.80,
+            damage: 2,
+            description: "\n80% chance of causing a strong attack",
+        },
+        "critical":{
+            name: "critical",
+            type: "attack",
+            answer: null,
+            chanceforSuccess: 0.40,
+            damage: 4,
+            description: "\n40% chance of causing a brutal attack",
+        },
+        "disarm":{
+            name: "disarm",
+            type: "disarm",
+            answer: null,
+            chanceforSuccess: 0.25,
+            damage: 0.2,
+            description: "\n25% chance of lowering boss attack",
+        },
+        "heal":{
+            name: "heal",
+            type: "heal",
+            answer: null,
+            chanceforSuccess: 0.90,
+            damage: 0.25,
+            description: "\n90% chance of healing a teammate",
+        },
+        "poke":{
+            name: "poke",
+            type: "attack",
+            answer: null,
+            chanceforSuccess: 0.1,
+            damage: 0.05,
+            description: "\n10% chance of poking the enemy",
+        },
+    };
+    if (num) {
+      const alphabet = ["a", "b", "c", "d", "e"];
+        const shuffled = Object
+            .entries(weaponInformation)
+            .sort(() => 0.5 - Math.random())
+            .slice(0, num)
+            .reduce((obj, [k, v]) => ({
+                ...obj,
+                [k]: v,
+            }), {});
+            // Sorry
+            for (const i in Object.keys(shuffled)) {
+              shuffled[Object.keys(shuffled)[i]].answer = alphabet[i];
+            }
+        return shuffled;
+      }
+    if (weapon) {
+      return weaponInformation[weapon];
+    }
+    return weaponInformation;
+};
+const dungeonBossStartAllowed = (user)=>{
+    // checks for cooldown
+    const cooldownInfo = onCooldown("dungeon", user);
+    if (cooldownInfo.response) {
+        return cooldownInfo.embed;
+    }
+
+    const { currentLocation } = user.world;
+    const locationIcon = getLocationIcon(currentLocation);
+    const dungeonInformation = Object.values(worldLocations[currentLocation].places).find(p=>{
+        return p.type === "dungeon";
+    });
+
+    if (!user.world.locations[currentLocation].explored.includes([dungeonInformation.name])) {
+        return `You haven't found any dungeon in ${locationIcon} ${currentLocation}`;
+    }
+
+    // Checks if user has the correct key
+    const requiredDungeonKey = dungeonInformation.requires;
+    if (!user.hero.dungeonKeys[requiredDungeonKey]) {
+        let response = `You try to enter ${dungeonInformation.name}, but you don't have the required ${getDungeonKeyIcon(requiredDungeonKey)} ${requiredDungeonKey} to proceed. `;
+        if (user.hero.rank < 2) {
+            response += `Try defeating the dungeon in ${locationIcon} ${currentLocation} to obtain the required dungeon key`;
+        }
+        return response;
+    }
+
+    if (user.hero.currentHealth < user.hero.health * 0.05) {
+        let feedback = `Your hero's health is too low (**${user.hero.currentHealth}**)`;
+        if (user.hero.rank < 2) {
+            feedback += "\n You can `!build` a shop and `!build` potions";
+        }
+        return feedback;
+    }
+    return null;
+};
+const validateHelper = async discordId =>{
+    const user = await User.findOne({ "account.userId": discordId }).lean();
+    return user.hero.currentHealth > user.hero.health * 0.05;
+};
+
+const randomIntBetweenMinMax = (min, max) => {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+  };
+
+module.exports = { getWeaponInfo, dungeonBossStartAllowed, validateHelper, randomIntBetweenMinMax };

--- a/game/dungeon/index.js
+++ b/game/dungeon/index.js
@@ -1,0 +1,197 @@
+const { onCooldown } = require("../_CONSTS/cooldowns");
+const { worldLocations } = require("../_CONSTS/explore");
+const { getLocationIcon, getDungeonIcon } = require("../_CONSTS/icons");
+const { createMinibossInvitation, createMinibossResult } = require("./embedGenerator");
+
+const User = require("../../models/User");
+
+// Note: The success of defeating the miniboss is based soley on user rank
+const handleDungeon = async (message, user)=>{
+
+    // cooldown, health, explored miniboss
+    const disallowed = dungeonStartAllowed(user);
+		if (disallowed) {
+			return disallowed;
+        }
+
+    const miniboss = createMinibossEvent(user);
+
+    const now = new Date();
+    await user.setNewCooldown("miniboss", now);
+
+    const minibossInvitation = createMinibossInvitation(miniboss, user);
+    const invitation = await message.channel.send(minibossInvitation);
+
+    await invitation.react("🧟");
+
+    const reactionFilter = (reaction) => {
+        return reaction.emoji.name === "🧟";
+    };
+
+    const collector = await invitation.createReactionCollector(reactionFilter, { time: 1000 * 20, errors: ["time"] });
+    collector.on("collect", async (result, rUser) => {
+        if (rUser.bot || miniboss.helpers.length > 9) {
+            return;
+        }
+        const allowedHelper = await validateHelper(rUser.id);
+        if (!allowedHelper) {
+            return;
+        }
+        miniboss.helpers.push(rUser.id);
+    });
+
+     collector.on("end", async () => {
+        const result = await calculateMinibossResult(miniboss);
+        const embed = createMinibossResult(result, miniboss);
+        message.channel.send(embed);
+});
+};
+
+const dungeonStartAllowed = (user)=>{
+    // checks for cooldown
+    const cooldownInfo = onCooldown("dungeon", user);
+    if (cooldownInfo.response) {
+        return cooldownInfo.embed;
+    }
+
+    const { currentLocation } = user.world;
+    const locationIcon = getLocationIcon(currentLocation);
+    const dungeonInformation = Object.values(worldLocations[currentLocation].places).find(p=>{
+        return p.type === "dungeon";
+    });
+
+    // Checks if user has the correct key
+    const requiredDungeonKey = dungeonInformation.requires;
+    if (user.hero.dungeonKeys[requiredDungeonKey]) {
+        let response = `You try to enter ${dungeonInformation.name}, but you don't have the required ${getDungeonIcon(requiredDungeonKey)} ${requiredDungeonKey} to proceed. `;
+        if (user.hero.rank < 2) {
+            response += `Try defeating the Miniboss in ${locationIcon} ${currentLocation} to obtain the required dungeon key`;
+        }
+        return response;
+    }
+
+
+    // checks for too low hp
+    {
+if (user.hero.currentHealth < user.hero.health * 0.05) {
+        let feedback = `Your hero's health is too low (**${user.hero.currentHealth}**)`;
+        if (user.hero.rank < 2) {
+            feedback += "\n You can `!build` a shop and `!build` potions";
+        }
+        return feedback;
+    }
+}
+
+
+    if (!user.world.locations[currentLocation].explored.includes([dungeonInformation.name])) {
+        return `You haven't found any dungeon in ${locationIcon} ${currentLocation}`;
+    }
+
+    return null;
+};
+
+const createMinibossEvent = (user) =>{
+    const { currentLocation } = user.world;
+    const minibossname = Object.keys(worldLocations[currentLocation].places).find(p=>{
+        return worldLocations[currentLocation].places[p].type === "miniboss";
+    });
+    const miniboss = worldLocations[currentLocation].places[minibossname];
+    miniboss.helpers.push(user.account.userId);
+    return miniboss;
+};
+
+const validateHelper = async discordId =>{
+    const user = await User.findOne({ "account.userId": discordId }).lean();
+    return user.hero.currentHealth > user.hero.health * 0.05;
+};
+
+
+const calculateMinibossResult = async (miniboss)=>{
+    const users = await User.find({ "account.userId": miniboss.helpers });
+
+    const initiativeTaker = users.filter(u=>{
+        return u.account.userId === miniboss.helpers[0];
+    });
+    const helpers = users.filter(u=>{
+        return u.account.userId !== miniboss.helpers[0];
+    });
+
+    let chanceForSuccess = helpers.reduce((acc, cur)=>{
+        return acc + cur.hero.rank;
+    }, 0) + initiativeTaker[0].hero.rank + 2;
+
+    // Temporary workaround for testcases
+    if (initiativeTaker[0].account.testUser) {
+        chanceForSuccess -= 2;
+    }
+    const randomNumber = Math.random() * 10;
+
+    const result = {
+            win: false,
+            initiativeTaker: initiativeTaker[0],
+            helpers: helpers,
+            rewards:{
+                initiativeTaker:{
+                    dungeonKey: null,
+                    gold: Math.round(miniboss.rewards.gold / 2),
+                    xp: Math.round(miniboss.rewards.xp / 2),
+                },
+                helpers:[],
+            },
+            damageDealt:{
+                initiativeTaker: Math.floor(Math.random() * miniboss.stats.attack),
+                initiativeTakerDead:false,
+                helpers:[],
+            },
+    };
+    if (result.damageDealt.initiativeTaker >= result.initiativeTaker.hero.currentHealth) {
+        result.damageDealt.initiativeTakerDead = true;
+    }
+    if (chanceForSuccess > randomNumber) {
+        result.win = true;
+        if(result.initiativeTaker.hero.rank >= 2) {
+            result.rewards.initiativeTaker.dungeonKey = miniboss.rewards.dungeonKey;
+        }
+        await result.initiativeTaker.alternativeGainXp(result.rewards.initiativeTaker.xp);
+        await result.initiativeTaker.gainManyResources({ gold: result.rewards.initiativeTaker.gold });
+        await result.initiativeTaker.giveDungeonKey(result.rewards.initiativeTaker.dungeonKey);
+        await asyncForEach(result.helpers, async (h) => {
+            const randomHelperXp = Math.round((Math.random() * miniboss.rewards.xp) / helpers.length);
+            const randomHelperGold = Math.round((Math.random() * miniboss.rewards.gold) / helpers.length);
+            const helperName = h.account.username;
+            const helperLeveledUp = randomHelperXp + h.hero.currentExp > h.hero.expToNextRank;
+            await h.alternativeGainXp(randomHelperXp);
+            await h.gainManyResources({ gold:randomHelperGold });
+            result.rewards.helpers.push({
+                randomHelperXp,
+                randomHelperGold,
+                helperName,
+                helperLeveledUp,
+            });
+        });
+    }
+ else {
+    await result.initiativeTaker.heroHpLossFixedAmount(result.damageDealt.initiativeTaker);
+
+    await asyncForEach(result.helpers, async (h)=>{
+        const randomHelperDamage = Math.round(Math.random() * miniboss.stats.attack) ;
+        const helperDead = h.hero.currentHealth - randomHelperDamage <= 0;
+        await h.heroHpLossFixedAmount(randomHelperDamage);
+        result.rewards.helpers.push({
+            randomHelperDamage,
+            helperDead,
+        });
+    });
+    }
+    return result;
+};
+
+
+async function asyncForEach(array, callback) {
+    for (let index = 0; index < array.length; index += 1) {
+      await callback(array[index], index, array);
+    }
+  }
+
+
+module.exports = { handleDungeon, createMinibossEvent, dungeonStartAllowed, createMinibossResult, calculateMinibossResult };

--- a/game/dungeon/rooms.js
+++ b/game/dungeon/rooms.js
@@ -1,0 +1,79 @@
+const { worldLocations } = require("../_CONSTS/explore");
+const { dungeonStartAllowed } = require("./helper");
+
+const { calculatePveFullArmyResult } = require("../../combat/combat");
+const { generateEmbedPveFullArmy } = require("../../combat/pveEmedGenerator");
+
+const { handleDungeonBoss } = require("./index");
+
+const handleDungeonRooms = async (message, user)=>{
+    const { currentLocation } = user.world;
+    const dungeonInformation = Object.values(worldLocations[currentLocation].places).find(p=>{
+        return p.type === "dungeon";
+    });
+    const { rooms } = dungeonInformation;
+    const progress = {
+        user,
+        currentRoom:0,
+        rooms,
+    };
+    await startDungeonRooms(message, progress);
+};
+
+const startDungeonRooms = async (message, progress)=>{
+    const { user } = progress;
+
+    const disallowed = dungeonStartAllowed(user);
+		if (disallowed) {
+            return message.channel.send(disallowed);
+        }
+
+// perform raid
+const placeInfo = progress.rooms[progress.currentRoom];
+const raidResult = calculatePveFullArmyResult(user, placeInfo);
+
+ // saves to database
+await user.unitLoss(raidResult.lossPercentage);
+await user.alternativeGainXp(raidResult.expReward);
+if (raidResult.win) {
+    await user.gainManyResources(raidResult.resourceReward);
+}
+// generates a Discord embed
+const raidEmbed = generateEmbedPveFullArmy(user, placeInfo, raidResult, true);
+const msg = await message.channel.send(raidEmbed);
+try {
+    await msg.react("✅");
+    await msg.react("🚫");
+}
+catch (err) {
+    console.error("error: ", err);
+}
+
+
+const filter = (reaction, rUser) => {
+	return rUser.id === progress.user.account.userId;
+};
+
+msg.awaitReactions(filter, { max: 1, time: 1000 * 20, errors: ["time"] })
+	.then(collected => {
+		const reaction = collected.first();
+		if (reaction.emoji.name === "✅") {
+            progress.currentRoom += 1;
+
+            if (progress.currentRoom > 2) {
+                return handleDungeonBoss(message, user);
+            }
+ else {
+                startDungeonRooms(message, progress);
+            }
+		}
+        else {
+        return msg.reply("you chose to flee");
+		}
+	})
+	.catch(() => {
+    return msg.reply("You did not choose anything and therefor fled the dungeon");
+    });
+};
+
+module.exports = { handleDungeonRooms };

--- a/game/hunt/index.js
+++ b/game/hunt/index.js
@@ -85,6 +85,10 @@ const handleHunt = async (user, place = null) => {
     return `${place} does not exist in ${locationIcon} ${currentLocation}. Use !look to see your surroundings`;
 }
 
+if (!userExploredPlaces.includes(placeInfo.name)) {
+    return "You haven't explored this place yet. Try `!explore` in order to find it!";
+}
+
     // calculates result
  const huntResult = calculatePveHero(user, placeInfo);
 

--- a/game/look/index.js
+++ b/game/look/index.js
@@ -13,7 +13,6 @@ const getWorld = (user) => {
 
 	const exploredPlaces = user.world.locations[currentLocation].explored;
 	const exploredPlacesWithIcons = exploredPlaces.length ? exploredPlaces.map(place=>{
-		console.log(place, "place");
 		const type = worldLocations[currentLocation].places[place].type;
 		return `${getPlaceIcon(type)} ${place}`;
 	}) : defaultNonExplored;

--- a/game/look/index.js
+++ b/game/look/index.js
@@ -13,6 +13,7 @@ const getWorld = (user) => {
 
 	const exploredPlaces = user.world.locations[currentLocation].explored;
 	const exploredPlacesWithIcons = exploredPlaces.length ? exploredPlaces.map(place=>{
+		console.log(place, "place");
 		const type = worldLocations[currentLocation].places[place].type;
 		return `${getPlaceIcon(type)} ${place}`;
 	}) : defaultNonExplored;

--- a/game/miniboss/embedGenerator.js
+++ b/game/miniboss/embedGenerator.js
@@ -1,5 +1,5 @@
 const Discord = require("discord.js");
-const { getLocationIcon, getPlaceIcon, getDungeonIcon, getGreenRedIcon, getResourceIcon } = require("../_CONSTS/icons");
+const { getLocationIcon, getPlaceIcon, getDungeonKeyIcon, getGreenRedIcon, getResourceIcon } = require("../_CONSTS/icons");
 
 const createMinibossInvitation = (miniboss, user)=>{
     const sideColor = "#45b6fe";
@@ -9,7 +9,7 @@ const createMinibossInvitation = (miniboss, user)=>{
     const minibossIcon = getPlaceIcon("miniboss");
 
         const rules = `\`Army allowed: ${getGreenRedIcon(miniboss.rules.allowArmy)}\`\n \`Miniboss deadly: ${getGreenRedIcon(miniboss.rules.canKill)}\`\n \`Helpers allowed: ${getGreenRedIcon(miniboss.rules.allowHelpers)}\``;
-        const rewards = `${getResourceIcon("gold")} \`Gold: ${miniboss.rewards.gold}\`\n ${getResourceIcon("xp")} \`XP: ${miniboss.rewards.xp}\` \n ${getDungeonIcon(miniboss.rewards.dungeonKey)} \` Key: ${miniboss.rewards.dungeonKey}\``;
+        const rewards = `${getResourceIcon("gold")} \`Gold: ${miniboss.rewards.gold}\`\n ${getResourceIcon("xp")} \`XP: ${miniboss.rewards.xp}\` \n ${getDungeonKeyIcon(miniboss.rewards.dungeonKey)} \` Key: ${miniboss.rewards.dungeonKey}\``;
 
         const embedInvitation = new Discord.MessageEmbed()
             .setTitle(`A Miniboss has been triggered by ${username}!`)
@@ -82,7 +82,7 @@ const createMinibossInvitation = (miniboss, user)=>{
 
         let initiativeTakerRewards = `${getResourceIcon("gold")} Gold: ${result.rewards.initiativeTaker.gold} \n\n ${getResourceIcon("xp")} XP: ${result.rewards.initiativeTaker.xp}`;
         if (result.rewards.initiativeTaker.dungeonKey) {
-            initiativeTakerRewards += `\n\n ${getDungeonIcon(result.rewards.initiativeTaker.dungeonKey)} ${result.rewards.initiativeTaker.dungeonKey} !`;
+            initiativeTakerRewards += `\n\n ${getDungeonKeyIcon(result.rewards.initiativeTaker.dungeonKey)} ${result.rewards.initiativeTaker.dungeonKey} !`;
         }
         const minibossIcon = getPlaceIcon("miniboss");
         const fields = [

--- a/game/miniboss/index.js
+++ b/game/miniboss/index.js
@@ -4,10 +4,8 @@ const { getLocationIcon } = require("../_CONSTS/icons");
 const { createMinibossInvitation, createMinibossResult } = require("./embedGenerator");
 
 const User = require("../../models/User");
-/* const { calculatePveFullArmyResult } = require("../../combat/combat");
-const { generateEmbedPveFullArmy } = require("../../combat/pveEmedGenerator"); */
 
-
+// Note: The success of defeating the miniboss is based soley on user rank
 const handleMiniboss = async (message, user)=>{
 
     // cooldown, health, explored miniboss

--- a/game/profile/index.js
+++ b/game/profile/index.js
@@ -1,6 +1,6 @@
 const Discord = require("discord.js");
 const { determineSupporterTitle, getAllSoldiers, getPlayerPosition } = require("./helper");
-const { getDungeonIcon } = require("../_CONSTS/icons");
+const { getDungeonKeyIcon } = require("../_CONSTS/icons");
 const calculateStats = require("../../combat/calculate-stats");
 
 const prettifyUser = async (message, user) => {
@@ -52,7 +52,7 @@ const prettifyUser = async (message, user) => {
 
 	Object.keys(hero.dungeonKeys).forEach(dk=>{
 		if (hero.dungeonKeys[dk] && !dk.startsWith("$")) {
-			dungeonKeys.value.push(`${getDungeonIcon(dk)} ${dk} \n`);
+			dungeonKeys.value.push(`${getDungeonKeyIcon(dk)} ${dk} \n`);
 		}
 	});
 	if (dungeonKeys.value.length) {

--- a/game/raid/index.js
+++ b/game/raid/index.js
@@ -82,6 +82,10 @@ const handleRaid = async (user, place = null) => {
     return `${place} does not exist in ${locationIcon} ${currentLocation}. Use !look to see your surroundings`;
 }
 
+if (!userExploredPlaces.includes(placeInfo.name)) {
+    return "You haven't explored this place yet. Try `!explore` in order to find it!";
+}
+
     // calculates result
  const raidResult = calculatePveFullArmyResult(user, placeInfo);
 
@@ -95,7 +99,7 @@ if (raidResult.win) {
 }
 
 // generates a Discord embed
-    const raidEmbed = generateEmbedPveFullArmy(user, placeInfo, raidResult);
+const raidEmbed = generateEmbedPveFullArmy(user, placeInfo, raidResult);
  return raidEmbed;
 
 };

--- a/game/travel/index.js
+++ b/game/travel/index.js
@@ -1,0 +1,28 @@
+const { worldLocations } = require("../_CONSTS/explore");
+const { getLocationIcon } = require("../_CONSTS/icons");
+const handleTravel = async (user, travelDestination) => {
+    const { currentLocation } = user.world;
+
+    const playerUnlockedLocations = Object.keys(user.world.locations)
+        .filter(location=> user.world.locations[location].available)
+        .map(location=> location.split(" ").join("").toLowerCase("").substring(0, 4));
+
+    if (playerUnlockedLocations.length < 2) {
+        return `You haven't unlocked anything but ${getLocationIcon(currentLocation)} ${currentLocation}`;
+    }
+    const shortAnswer = travelDestination.substring(0, 4);
+    // allows the player to not type out the ful name
+    if (playerUnlockedLocations.includes(shortAnswer)) {
+        const newDestination = Object.keys(worldLocations).filter(location=>{
+            return location.split(" ").join("").toLowerCase("").substring(0, 4) === shortAnswer;
+        });
+        const worldDescription = worldLocations[newDestination[0]].description;
+        await user.locationTravel(newDestination[0]);
+        return `You traveled to ${getLocationIcon(newDestination)} ${newDestination[0]}\n${worldDescription}`;
+    }
+
+    return "You can't travel there. Try ` !look ` to see your available locations - if any..";
+};
+
+
+module.exports = { handleTravel };

--- a/models/User.js
+++ b/models/User.js
@@ -564,11 +564,12 @@ userSchema.methods.removeExp = async function(exp, newExpToNextRank, statRemoval
 	return this.save();
 };
 
-userSchema.methods.buyItem = async function(item) {
-	this.resources.gold -= item.price;
+userSchema.methods.buyItem = async function(item, giveAway = false) {
+	if (!giveAway) {
+		this.resources.gold -= item.price;
+	}
 
 	this.hero.inventory[item.name] += 1;
-
 	this.markModified("hero.inventory");
 
 	return this.save();
@@ -614,7 +615,7 @@ userSchema.methods.alternativeGainXp = async function(xp = 0) {
 		this.hero.currentExp += xp;
 	}
 	if (this.hero.currentExp >= this.hero.expToNextRank) {
-		if (heroExpToNextLevel.length > this.hero.rank) {
+		if (heroExpToNextLevel.length > this.hero.rank + 1) {
 			this.hero.rank += 1;
 			this.hero.expToNextRank = heroExpToNextLevel[this.hero.rank];
 				Object.keys(heroStatIncreaseOnLevel[this.hero.rank]).forEach(s=>{
@@ -624,6 +625,18 @@ userSchema.methods.alternativeGainXp = async function(xp = 0) {
 	}
 	return this.save();
 };
+
+userSchema.methods.unlockNewLocation = async function(location) {
+	this.world.locations[location].available = true;
+
+	return this.save();
+};
+
+userSchema.methods.locationTravel = async function(location) {
+	this.world.currentLocation = location;
+	return this.save();
+};
+
 
 userSchema.methods.giveDungeonKey = async function(key = "Ogre tooth") {
 	if (this.hero.dungeonKeys[key]) {

--- a/models/User.js
+++ b/models/User.js
@@ -614,11 +614,13 @@ userSchema.methods.alternativeGainXp = async function(xp = 0) {
 		this.hero.currentExp += xp;
 	}
 	if (this.hero.currentExp >= this.hero.expToNextRank) {
-		this.hero.rank += 1;
-		this.hero.expToNextRank = heroExpToNextLevel[this.hero.rank];
+		if (heroExpToNextLevel.length > this.hero.rank) {
+			this.hero.rank += 1;
+			this.hero.expToNextRank = heroExpToNextLevel[this.hero.rank];
 				Object.keys(heroStatIncreaseOnLevel[this.hero.rank]).forEach(s=>{
 					this.hero[s] += heroStatIncreaseOnLevel[this.hero.rank][s];
 				});
+			}
 	}
 	return this.save();
 };

--- a/models/userValues/default.js
+++ b/models/userValues/default.js
@@ -7,6 +7,10 @@ const cooldowns = {
         type:Date,
         default:0,
     },
+    dungeon:{
+        type:Date,
+        default:0,
+    },
     explore: {
         type:Date,
         default:0,


### PR DESCRIPTION
!dungeon (uses dungeon from _CONST/explore. Starts with room and then boss
!travel travels to different world location
fix now not able to hunt raid unexplored places.

possible dungeon issues:
- Other people interfering with the dungeon run
- Players healing between rounds or otherwise do actions not connected to dungeon
- If another player triggers the dungeon while someone is in dungeon, the values might copy from current dungeon instead of a new one
- Possible issue with paralell saving to mongodb when attacking dungeon boss
- Most likely an temp issue with losing dungeon boss result view
