### PR TITLE
add minor adjustments

### DIFF
--- a/bin/seeds.js
+++ b/bin/seeds.js
@@ -59,6 +59,7 @@ for (let i = 0; i < 20; i++) {
 				},
 			},
 		},
+		completedQuests: Array.from({ length:Math.floor(Math.random() * 12) }, (n, j)=> `myFakeQuest${j}`)
 	});
 }
 

--- a/game/_CONSTS/icons.js
+++ b/game/_CONSTS/icons.js
@@ -1,74 +1,76 @@
-/* eslint-disable no-inline-comments */
 const icons = {
 	// Resources
-	"gold": ":moneybag:", // 💰
+	"gold": { name:":moneybag:", icon:"💰" },
 
-	"oak wood": ":evergreen_tree:", // 🌳
-	"yew wood": ":deciduous_tree:",
-	"barlind wood": ":tanabata_tree:", // 🎋
+	"oak wood":{ name: ":evergreen_tree:", icon: "🌲" },
+	"yew wood":{ name: ":deciduous_tree:", icon: "🌳" },
+	"barlind wood":{ name: ":tanabata_tree:", icon: "🎋" },
 
-	"copper ore": ":orange_circle:",
-	"iron ore": ":white_circle:",
-	"obsidian ore": ":black_circle:",
+	"copper ore":{ name: ":orange_circle:", icon: "🟠" },
+	"iron ore":{ name: ":white_circle:", icon: "⚪️" },
+	"obsidian ore":{ name: ":black_circle:", icon: "⚫️" },
 
-	"bronze bar": ":orange_square:",
-	"iron bar": ":white_large_square:",
-	"steel bar": ":brown_square:",
+	"bronze bar":{ name: ":orange_square:", icon: "🟧" },
+	"iron bar":{ name: ":white_large_square:", icon: "⬜️" },
+	"steel bar":{ name: ":brown_square:", icon: "🟫" },
 
 	// Universe
-	"Grassy Plains" : ":deciduous_tree:", // 🌳
-	"Misty Mountains" : ":mountain_snow:", // 🏔
-	"Deep Caves" : ":volcano:", // 🌋
+	"Grassy Plains" :{ name: ":deciduous_tree:", icon: "🌳" },
+	"Misty Mountains" :{ name: ":mountain_snow:", icon: "🏔" },
+	"Deep Caves" :{ name: ":volcano:", icon: "🌋" },
 
 	// actions
-	"raid": ":man_supervillain:", // 🦹‍♂️
-	"hunt": ":frog:", // 🐸
-	"miniboss": ":zombie:", // 🧟
-	"fish": ":blowfish:", // 🐡
-	"dungeon": ":map:", // 🗺
+	"raid":{ name: ":man_supervillain:", icon: "🦹‍♂️" },
+	"hunt":{ name: ":frog:", icon: "🐸" },
+	"miniboss":{ name: ":zombie:", icon: "🧟" },
+	"fish":{ name: ":blowfish:", icon: "🐡" },
+	"dungeon":{ name: ":map:", icon: "🗺" },
 
 	// dungeon keys
-	"CM Key":":key2:", // 🗝
-	"The One Shell":":shell:", // 🐚
-	"Eridian Vase": ":amphora:", // 🏺
+	"CM Key":{ name: ":key2:", icon: "🗝" },
+	"The One Shell":{ name: ":shell:", icon: "🐚" },
+	"Eridian Vase":{ name: ":amphora:", icon: "🏺" },
 
 	// Military units
-	"archery":":archery:",
-	"barracks": ":crossed_swords:",
+	"archery":{ name: ":archery:", icon: "🏹" },
+	"barracks":{ name: ":crossed_swords:", icon: "⚔️" },
 
 	// Equipment Types
-	"weapon": ":probing_cane:",
-	"helmet": ":helmet_with_cross:",
-	"chest": ":womans_clothes:",
-	"legging": ":jeans:",
+	"weapon":{ name: ":probing_cane:", icon: "🦯" },
+	"helmet":{ name: ":helmet_with_cross:", icon: "⛑" },
+	"chest":{ name: ":womans_clothes:", icon: "👚" },
+	"legging":{ name: ":jeans:", icon: "👖" },
 
 	// Stats
-	"xp": ":mortar_board:", // 🎓
-	"health": ":heart:", // ❤️
-	"attack": ":crossed_swords:", // ⚔️
-	"defense": ":shield:", // 🛡
+	"xp":{ name: ":mortar_board:", icon: "🎓" },
+	"health":{ name: ":heart:", icon: "❤️" },
+	"attack":{ name: ":crossed_swords:", icon: "⚔️" },
+	"defense":{ name: ":shield:", icon: "🛡" },
 
 	// Hero
-	"armor": ":martial_arts_uniform:",
-	"inventory": ":school_satchel:",
+	"armor":{ name: ":martial_arts_uniform:", icon: "🥋" },
+	"inventory":{ name: ":school_satchel:", icon: "🎒" },
 
 	// dungeon weapons
-	"strike": ":knife:", // 🔪
-	"critical": ":bangbang:", // ‼️
-	"slash": ":dagger:", // 🗡
-	"disarm": ":dove:", // 🕊
-	"heal": ":test_tube:", // 🧪
-	"poke": ":point_right:", // 👉
+	"strike":{ name: ":knife:", icon: "🔪" },
+	"critical":{ name: ":bangbang:", icon: "‼️" },
+	"slash":{ name: ":dagger:", icon: "🗡" },
+	"disarm":{ name: ":dove:", icon: "🕊" },
+	"heal":{ name: ":test_tube:", icon: "🧪" },
+	"poke":{ name: ":point_right:", icon: "👉" },
 
 	// Misc
-	"false": ":x:", // ❌
-	"true": ":white_check_mark:" // ✅
+	"false":{ name: ":x:", icon: "❌" },
+	"true":{ name: ":white_check_mark:", icon: "✅" },
 };
 /**
  * Returns an emoji if configured in icons-object or a danger symbol if missing
  * @param {string} type - eg: "gold", "copper ore" or "true"
+ * @param {string} style - enum: "name" (":knife:") or "icon" ("🔪")
+ * NOTE: message.react and icons in footer of embeds needs to be icon and not name.
  **/
-const getIcon = (type)=> icons[type] || "⚠️";
+
+const getIcon = (type, style = "name")=> icons[type] ? icons[type][style] : "⚠️";
 
 
 module.exports = { getIcon };

--- a/game/_CONSTS/icons.js
+++ b/game/_CONSTS/icons.js
@@ -62,6 +62,8 @@ const icons = {
 	// Misc
 	"false":{ name: ":x:", icon: "❌" },
 	"true":{ name: ":white_check_mark:", icon: "✅" },
+	"weeklyPrizeStar":{ name:"star2", icon:"🌟" },
+	"dailyPrizeStar": { name:"star", icon: "⭐️" }
 };
 /**
  * Returns an emoji if configured in icons-object or a danger symbol if missing

--- a/game/_GLOBAL_HELPERS/index.js
+++ b/game/_GLOBAL_HELPERS/index.js
@@ -47,5 +47,14 @@ const randomIntBetweenMinMax = (min, max) => {
 	return Math.floor(Math.random() * (max - min + 1) + min);
 };
 
+// works as .filter for arrays, but objects
+// https://stackoverflow.com/questions/5072136/javascript-filter-for-objects
+// usage: objectFilter(someObject, x => x > 1);
+const objectFilter = (obj, predicate) => {
+	return Object.keys(obj)
+		.filter(key => predicate(obj[key]))
+		.reduce((res, key) => (res[key] = obj[key], res), {});
+};
 
-module.exports = { asyncForEach, deepCopyFunction, eloCalculations, randomIntBetweenMinMax };
+
+module.exports = { asyncForEach, deepCopyFunction, eloCalculations, randomIntBetweenMinMax, objectFilter };

--- a/game/dailyPrize/index.js
+++ b/game/dailyPrize/index.js
@@ -32,7 +32,8 @@ const generatePrizeEmbed = (result, consecutiveDay)=>{
 	const sideColor = "#45b6fe";
 
 	const preTitle = " DAILY PRIZE  ";
-	const consecutiveStars = "⭐️".repeat(consecutiveDay + 1);
+	const star = getIcon("dailyPrizeStar", "icon");
+	const consecutiveStars = star.repeat(consecutiveDay + 1);
 
 	const title = `${consecutiveStars} ${preTitle} ${consecutiveStars}`;
 	// "⭐️⭐️⭐️ DAILY PRIZE ⭐️⭐️⭐️"

--- a/game/dungeon/embedGenerator.js
+++ b/game/dungeon/embedGenerator.js
@@ -47,7 +47,7 @@ const createDungeonInvitation = (dungeon, user) => {
 		.addFields(
 			...fields,
 		)
-		.setFooter(`React with a ${getIcon("dungeon")} within 20 seconds to participate! (max 5!)`);
+		.setFooter(`React with a ${getIcon("dungeon", "icon")} within 20 seconds to participate! (max 5!)`);
 	return embedInvitation;
 };
 
@@ -304,7 +304,7 @@ function generateRoomEmbed(user, placeInfo, results, questIntro = false) {
 		.addFields(
 			...fields,
 		)
-		.setFooter("Proceed? 🚫 / ✅");
+		.setFooter(`Proceed? ${getIcon(false, "icon")} / ${getIcon(true, "icon")}`);
 	return embedWin;
 }
 

--- a/game/dungeon/index.js
+++ b/game/dungeon/index.js
@@ -4,6 +4,7 @@ const { startDungeonRooms } = require("./rooms");
 const { createDungeonInvitation } = require("./embedGenerator");
 const { dungeonStartAllowed, validateHelper } = require("./helper");
 const { deepCopyFunction } = require("../_GLOBAL_HELPERS/");
+const { getIcon } = require("../_CONSTS/icons");
 
 const handleDungeon = async (message, user)=>{
 	// cooldown, health, explored dungeon and dungeon key
@@ -19,10 +20,12 @@ const handleDungeon = async (message, user)=>{
 
 	const dungeonInvitation = createDungeonInvitation(dungeon, user);
 	const invitation = await message.channel.send(dungeonInvitation);
-	await invitation.react("🗺");
+	const dungeonIcon = getIcon("dungeon", "icon");
+
+	await invitation.react(dungeonIcon);
 
 	const reactionFilter = (reaction) => {
-		return reaction.emoji.name === "🗺";
+		return reaction.emoji.name === dungeonIcon;
 	};
 
 	const collector = await invitation.createReactionCollector(reactionFilter, { time: 1000 * 20, errors: ["time"] });

--- a/game/look/index.js
+++ b/game/look/index.js
@@ -23,7 +23,7 @@ const getWorld = (user) => {
 
 	Object.keys(worldLocations[currentLocation].places).map(p=>{
 		const { type } = worldLocations[currentLocation].places[p];
-		legend.add(`${getIcon(type)}: !${type} - `);
+		legend.add(`${getIcon(type, "icon")} : !${type} - `);
 	});
 	const footerFriendlyLegend = Array.from(legend).join("");
 	const fields = [

--- a/game/miniboss/embedGenerator.js
+++ b/game/miniboss/embedGenerator.js
@@ -78,9 +78,9 @@ const createMiniBossResultWin = (result, minibossEvent) =>{
 	const sideColor = "#45b6fe";
 	const initiativeTaker = result.initiativeTaker.account.username;
 
-	let initiativeTakerRewards = `${getIcon("gold")} Gold: ${result.rewards.initiativeTaker.gold} \n\n ${getIcon("xp")} XP: ${result.rewards.initiativeTaker.xp}`;
+	let initiativeTakerRewards = `${getIcon("gold")} Gold: ${result.rewards.initiativeTaker.gold} \n ${getIcon("xp")} XP: ${result.rewards.initiativeTaker.xp}`;
 	if (result.rewards.initiativeTaker.dungeonKey) {
-		initiativeTakerRewards += `\n\n ${getIcon(result.rewards.initiativeTaker.dungeonKey)} ${result.rewards.initiativeTaker.dungeonKey} !`;
+		initiativeTakerRewards += `\n ${getIcon(result.rewards.initiativeTaker.dungeonKey)} ${result.rewards.initiativeTaker.dungeonKey} !`;
 	}
 	const minibossIcon = getIcon("miniboss");
 	const fields = [

--- a/game/miniboss/embedGenerator.js
+++ b/game/miniboss/embedGenerator.js
@@ -25,7 +25,7 @@ const createMinibossInvitation = (miniboss, user)=>{
 				inline: false,
 			},
 		)
-		.setFooter(`React with a ${getIcon("miniboss")} within 20 seconds to participate! (max 10!)`);
+		.setFooter(`React with a ${getIcon("miniboss", "icon")} within 20 seconds to participate! (max 10!)`);
 
 	return embedInvitation;
 };

--- a/game/quest/quest-helper.js
+++ b/game/quest/quest-helper.js
@@ -10,11 +10,10 @@ const questHelper = (user, questName, newPlaces, newQuests) => {
 
 		// If a new PvM location is required for the quest
 		if(newPlaces) {
-			const now = new Date();
 			newPlaces.forEach(newPlace => {
 				const { currentLocation, place: newlyExploredPlaceName } = newPlace;
 
-				user.handleExplore(now, currentLocation, newlyExploredPlaceName);
+				user.handleExplore(currentLocation, newlyExploredPlaceName);
 			});
 		}
 

--- a/game/rank/index.js
+++ b/game/rank/index.js
@@ -45,11 +45,27 @@ const getTop5Army = async (user)=>{
 };
 
 const getTop5Quest = async (user)=>{
-	const allUsers = await User
-		.find({})
-		.select(["account", "completedQuests"])
-		.sort({ "completedQuests":-1 })
-		.lean();
+
+	const allUsers = await User.aggregate([
+		{
+			$addFields: {
+				completedQuestsLength: {
+					$size: "$completedQuests"
+				}
+			}
+		},
+		{ $project:{
+			account:1,
+			completedQuestsLength:1,
+			completedQuests: 1
+		}
+		},
+		{
+			$sort: {
+				completedQuestsLength: -1
+			}
+		}
+	]);
 
 	const top5 = allUsers.slice(0, 5);
 

--- a/game/weeklyPrize/index.js
+++ b/game/weeklyPrize/index.js
@@ -31,7 +31,8 @@ const generatePrizeEmbed = (result, consecutiveWeek)=>{
 	const sideColor = "#45b6fe";
 
 	const preTitle = " WEEKLY PRIZE  ";
-	const consecutiveStars = "🌟".repeat(consecutiveWeek + 1);
+	const star = getIcon("weeklyPrizeStar", "icon");
+	const consecutiveStars = star.repeat(consecutiveWeek + 1);
 
 	const title = `${consecutiveStars} ${preTitle} ${consecutiveStars}`;
 	// "🌟🌟🌟 WEEKLY PRIZE 🌟🌟🌟"

--- a/models/User.js
+++ b/models/User.js
@@ -335,8 +335,7 @@ userSchema.methods.setNewCooldown = function(type, now) {
 	this.cooldowns[type] = now;
 };
 
-userSchema.methods.handleExplore = function(now, currentLocation, place) {
-	this.cooldowns.explore = now;
+userSchema.methods.handleExplore = function(currentLocation, place) {
 	if (!this.world.locations[currentLocation].explored.includes(place)) {
 		this.world.locations[currentLocation].explored.push(place);
 		this.markModified(this.world.locations[currentLocation].explored);


### PR DESCRIPTION
- miniboss tests now runs maximum 10 times to overcome random outcome
- icons have name and icon keys --> {name: ": knife :", icon: "🔪"} 
- `getIcon` function now has params that allows for returning either name or icon.
- globalhelpers add .filter for objects
- `!explore` is now easier with 80% success rate (if explored-array is empty)
- `!look` has working icons in footer
- miniboss result embed looks slightly nicer
- testusers from `seeds.js` has an completedQuests-array with random length < 12